### PR TITLE
fix(1): create data directory before writing recipes.json

### DIFF
--- a/backend/src/routes/recipes.js
+++ b/backend/src/routes/recipes.js
@@ -166,6 +166,7 @@ function readRecipes() {
 }
 
 function writeRecipes(recipes) {
+  fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
   fs.writeFileSync(DATA_FILE, JSON.stringify(recipes, null, 2), 'utf8');
 }
 


### PR DESCRIPTION
Fixes QA-reported bug from Feature #1 review cycle 1.

**Problem:** On fresh git clone, backend/src/data/ does not exist. writeRecipes() throws ENOENT and crashes the server.

**Fix:** Added fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true }) to writeRecipes() before the write. Also added backend/src/data/.gitkeep to track the directory.

**Verified:** rm -rf backend/src/data && node server.js -> starts cleanly, seeds 5 recipes.

---
Created by Antigravity Dev Agent